### PR TITLE
Expose metrics on ipv4

### DIFF
--- a/common/core/src/methods/setupMetrics.ts
+++ b/common/core/src/methods/setupMetrics.ts
@@ -266,6 +266,6 @@ export function setupMetrics(this: Node): void {
           res.end(metrics);
         }
       })
-      .listen(this.metricsPort);
+      .listen(this.metricsPort, "0.0.0.0");
   }
 }


### PR DESCRIPTION
This enables to expose metrics on ipv4 interface address, by default its listen only to ipv6